### PR TITLE
exclude bot's requests

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -275,7 +275,7 @@ func excludeBotRequestsHandler() echo.MiddlewareFunc {
 			}
 			for c := range ch {
 				if c {
-					return fmt.Errorf("request by bot: %s", ua)
+					return ctx.NoContent(http.StatusServiceUnavailable)
 				}
 			}
 			return nil


### PR DESCRIPTION
botからのリクエストについては503を返していいということなので、uaがbotだったら503を返すmiddlewareを実装しました。
https://gist.github.com/progfay/25edb2a9ede4ca478cb3e2422f1f12f6#bot-%E3%81%8B%E3%82%89%E3%81%AE%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88